### PR TITLE
Fixed Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CommonCrypto HMAC wrapper for Swift on OS X and iOS
-[![MIT Lincese](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
+[![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![CI Status](http://img.shields.io/travis/norio-nomura/HMAC.svg?style=flat)](https://travis-ci.org/norio-nomura/HMAC)
 
@@ -7,8 +7,8 @@ HMAC is a [CommonCrypto's HMAC](https://developer.apple.com/library/ios/document
 
 ## Requirements
 
-iOS 8 or later
-OS X 10.9 or later
+* iOS 8 or later
+* OS X 10.9 or later
 
 ## Installation
 


### PR DESCRIPTION
And also made the list a list so that iOS and OS X doesn't appear on the same line.
